### PR TITLE
機能: 関数にJSDocコメントを追加し、型定義を整理

### DIFF
--- a/src/utils/function/date/convertDateLabelToDate.ts
+++ b/src/utils/function/date/convertDateLabelToDate.ts
@@ -1,4 +1,8 @@
-// 日付ラベルを実際の日付に変換する関数
+/**
+ * 日付ラベルを実際の日付に変換する関数
+ * @param label 日付ラベル
+ * @returns 実際の日付
+ */
 export const convertDateLabelToDate = (label: string): Date => {
   const today = new Date()
   switch (label) {

--- a/src/utils/function/fetchUtil.ts
+++ b/src/utils/function/fetchUtil.ts
@@ -1,3 +1,8 @@
+/**
+ * fetchを使ってAPIからJSONを取得する関数
+ * @param url 取得するURL
+ * @returns JSON
+ */
 export async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url, {
     headers: {

--- a/src/utils/function/formatTweetQueryParams.ts
+++ b/src/utils/function/formatTweetQueryParams.ts
@@ -1,8 +1,7 @@
-import { GetNewsData } from "@/utils/type/api/GetNewsType"
-import { MarkerAnnotationData } from "./map/renderAnnotation"
+import { MarkerAnnotationData } from "@/utils/type/map/MapAnnotationType"
 
 /**
- * 🔄 マップアノテーションデータを Twitter API 用のクエリに変換する関数
+ * 🔄 マップアノテーションデータを Twitter API に渡すためのクエリに変換する関数
  *
  * @param {MapAnnotationData} data - 選択されたマップアノテーションデータ
  * @returns {string} 変換後の検索クエリ（例: `"ハッカソン,福岡市|ハッカソン,中央区|ハッカソン,天神"`）

--- a/src/utils/function/map/renderAnnotation.ts
+++ b/src/utils/function/map/renderAnnotation.ts
@@ -1,18 +1,14 @@
 import { GetNewsData, MapInstance, MapkitInstance } from "@/utils/type/api/GetNewsType"
 import { RefObject } from "react"
 import { categoryStyleMap } from "./categoryStyleMap"
+import { MarkerAnnotationData } from "@/utils/type/map/MapAnnotationType"
 
-export type MarkerAnnotationData = {
-  id: number
-  category: string
-  location: { lat: number; lng: number }
-  area: string
-  link: string
-  publishedAt: Date
-  markerImgUrl: string
-}
-
-// マーカーの表示をする関数
+/**
+ * マーカー（アノテーション）の表示をする関数
+ * @param mapRef マップのRef
+ * @param annotationRefs アノテーションのRef
+ * @param annotationData アノテーションのデータ
+ */
 export const renderAnnotations = (
   mapRef: RefObject<[MapInstance, MapkitInstance] | null>,
   annotationRefs: RefObject<Record<string, any>>,

--- a/src/utils/function/map/toCompatibleBounds.ts
+++ b/src/utils/function/map/toCompatibleBounds.ts
@@ -1,3 +1,8 @@
+/**
+ * mapkit.BoundingRegionを座標に変換する
+ * @param region mapkit.BoundingRegion
+ * @returns 座標
+ */
 export const toCompatibleBounds = (region: mapkit.BoundingRegion) => ({
   getSouthWest: (): [number, number] => [region.southLatitude, region.westLongitude],
   getNorthEast: (): [number, number] => [region.northLatitude, region.eastLongitude],

--- a/src/utils/type/map/MapAnnotationType.ts
+++ b/src/utils/type/map/MapAnnotationType.ts
@@ -1,3 +1,16 @@
+export type MarkerAnnotationData = {
+  id: number
+  category: string
+  location: { lat: number; lng: number }
+  area: string
+  link: string
+  publishedAt: Date
+  markerImgUrl: string
+}
+
+/**
+ * マップアノテーションの型
+ */
 export type MapAnnotationType = {
   id: number
   category: string // ニュースのカテゴリ
@@ -8,10 +21,7 @@ export type MapAnnotationType = {
   sourceName: string | null // ニュースの発信元
   sourceUrl: string | null // 発信元のURL
   clusteringIdentifier: string
-  data: {
-    area: string
-    link: string
-  }
+  data: MarkerAnnotationData
   markerImgUrl?: string // マーカーの画像
   publishedAt: Date // ニュースの公開日
   createdAt: Date // DBに登録された日時


### PR DESCRIPTION
- `fetchUtil.ts`、`formatTweetQueryParams.ts`、`convertDateLabelToDate.ts`、`renderAnnotation.ts`、`toCompatibleBounds.ts`にJSDocコメントを追加しました。
- `MapAnnotationType.ts`で`MarkerAnnotationData`型を定義し、`data`プロパティを更新しました。