### PR TITLE
機能: コンポーネントのリファクタリングと不要なインポートの削除

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
 import "./globals.css"
-import Head from "next/head"
 import Script from "next/script"
 import { Noto_Sans_JP } from "next/font/google"
 
@@ -118,15 +117,14 @@ export default function RootLayout({
 
   return (
     <html lang="en">
-      <Head>
-        <Script src="https://cdn.apple-mapkit.com/mk/5.0.x/mapkit.js"></Script>
-        <Script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(structuredData),
-          }}
-        />
-      </Head>
+      <Script src="https://cdn.apple-mapkit.com/mk/5.0.x/mapkit.js"></Script>
+      <Script
+        id="schema-data"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData),
+        }}
+      />
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${NotoSansJPFont.className} antialiased h-full w-full`}
       >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import { MapContainer } from "@/components/MapContainer/MapContainer"
 import { NEWS_API_ENDPOINT, GetNewsData } from "@/utils/type/api/GetNewsType"
 import { FIRE_API_ENDPOINT, GetFireData } from "@/utils/type/api/GetMissionType"
 import { serverFetchJson } from "@/utils/function/serverFetch"

--- a/src/components/AppleMap/AppleMap.tsx
+++ b/src/components/AppleMap/AppleMap.tsx
@@ -13,7 +13,6 @@ import { TweetList } from "../TweetList/TweetList"
 import { DetailSection } from "../DetailSection/DetailSection"
 import { DarkModeToggle } from "../DarkModeToggle/DarkModeToggle"
 import { RightSideContent } from "../RightSideContent/RightSideContent"
-import { HamburgerIcon } from "@/components/Icons/HamburgerIcon"
 import { convertDateLabelToDate } from "@/utils/function/date/convertDateLabelToDate"
 import { HamburgerToggle } from "../HamburgerToggle/HamburgerToggle"
 import { categoryStyleMap } from "@/utils/function/map/categoryStyleMap"
@@ -38,7 +37,6 @@ const dates = ["今日", "今日と昨日", "3日以内", "1週間以内", "1ヶ
 
 export const AppleMap = ({
   centerPoint,
-  mapOptions = {},
   zoom,
   onBoundsChanged,
   className,
@@ -47,6 +45,7 @@ export const AppleMap = ({
 }: AppleMapProps) => {
   const div = useRef<HTMLDivElement>(null)
   const mapRef = useRef<[MapInstance, MapkitInstance] | null>(null) // マップの状態管理用のref
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const annotationRefs = useRef<Record<string, any>>({}) // アノテーション（マップにある印）の状態管理用のref
   const [isSideFrameOpen, setIsSideFrameOpen] = useState<boolean>(false)
   const [selectedElement, setSelectedElement] = useState<HTMLElement | null>(null)
@@ -138,6 +137,8 @@ export const AppleMap = ({
 
       _initializeMap(mapkit)
     })
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [div, isDarkMode]) // isDarkModeが変わるたびに再レンダリング
 
   useEffect(() => {

--- a/src/components/RealtimeMapContainer/RealtimeMapContainer.tsx
+++ b/src/components/RealtimeMapContainer/RealtimeMapContainer.tsx
@@ -50,7 +50,7 @@ export function RealtimeMapContainer({ initialData }: RealtimeMapContainerProps)
       {/* 更新ボタン */}
       <button
         onClick={refreshData}
-        className="fixed top-4 right-4 z-10 bg-blue-500 text-white py-2 px-4 rounded shadow"
+        className="fixed top-2 right-4 z-10 bg-blue-500 text-white py-2 px-4 rounded shadow"
       >
         最新情報に更新
       </button>

--- a/src/components/TweetList/TweetList.tsx
+++ b/src/components/TweetList/TweetList.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { GetTweetData } from "@/utils/type/api/GetTweetType"
 import { HeartIcon } from "../Icons/HeartIcon"
 import { RetweetIcon } from "../Icons/RetweetIcon"
+import Image from "next/image"
 
 type TweetListProps = {
   tweets: GetTweetData[] | null
@@ -41,8 +42,11 @@ export const TweetList: React.FC<TweetListProps> = ({ tweets }) => {
           className="block border border-gray-300 w-full p-5 rounded-lg bg-white dark:bg-gray-800 shadow-md flex-col flex items-start gap-4 hover:bg-gray-100 transition"
         >
           <div className="flex items-start space-x-4">
-            <img
-              src={tweet.authorProfile || "https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png"}
+            <Image
+              src={
+                tweet.authorProfile ||
+                "https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png"
+              }
               alt="Profile"
               className="w-12 h-12 rounded-full"
             />
@@ -56,7 +60,7 @@ export const TweetList: React.FC<TweetListProps> = ({ tweets }) => {
           <div className="flex flex-col gap-3 w-full">
             <p className="text-lg text-gray-700 whitespace-pre-line">{tweet.text}</p>
             {tweet.mediaUrl && (
-              <img
+              <Image
                 src={tweet.mediaUrl}
                 alt="Tweet media"
                 className="rounded-lg border w-full object-cover"

--- a/src/utils/function/date/convertDateLabelToDate.ts
+++ b/src/utils/function/date/convertDateLabelToDate.ts
@@ -9,7 +9,6 @@ export const convertDateLabelToDate = (label: string): Date => {
     case "今日":
       return today
     case "今日と昨日":
-      const yesterday = new Date(today)
       today.setDate(today.getDate() - 1)
       return today
     case "3日以内":

--- a/src/utils/function/formatTweetQueryParams.ts
+++ b/src/utils/function/formatTweetQueryParams.ts
@@ -8,7 +8,7 @@ import { MarkerAnnotationData } from "../type/api/GetNewsType"
  */
 export const formatTweetQueryParams = (data: MarkerAnnotationData): string => {
   // 📌 エリア情報を都道府県・市区町村レベルまでにする（丁目・番地は除外）
-  let addressParts = data.address
+  const addressParts = data.address
     ?.replace(/[0-9０-９\-−丁目番地号]/g, "") // 「1丁目10−20」などの詳細住所を削除
     .replace(/市|区|町|村|県|府|道|都/g, " ") // 「市・区・町・村・県」をスペースに変換
     .split(/\s+/) // 空白で分割

--- a/src/utils/function/formatTweetQueryParams.ts
+++ b/src/utils/function/formatTweetQueryParams.ts
@@ -1,4 +1,4 @@
-import { MarkerAnnotationData } from "../type/api/GetNewsType"
+import { MarkerAnnotationData } from "../type/api/common/GetAnnotationsType"
 
 /**
  * 🔄 マップアノテーションデータを Twitter API に渡すためのクエリに変換する関数

--- a/src/utils/function/map/renderAnnotation.ts
+++ b/src/utils/function/map/renderAnnotation.ts
@@ -15,6 +15,7 @@ import { categoryStyleMap } from "./categoryStyleMap"
  */
 export const renderAnnotations = (
   mapRef: RefObject<[MapInstance, MapkitInstance] | null>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   annotationRefs: RefObject<Record<string, any>>,
   annotationData: GetNewsData[]
 ) => {
@@ -27,7 +28,7 @@ export const renderAnnotations = (
   const newAnnotations: mapkit.Annotation[] = []
   const [map, mapkit]: [MapInstance, MapkitInstance] = mapRef.current
 
-  annotationData.forEach((annotation, index) => {
+  annotationData.forEach((annotation) => {
     if (!annotation.id) {
       throw new Error("Marker must have a id.")
     }

--- a/src/utils/function/map/renderAnnotation.ts
+++ b/src/utils/function/map/renderAnnotation.ts
@@ -1,11 +1,7 @@
-import {
-  GetNewsData,
-  MapInstance,
-  MapkitInstance,
-  MarkerAnnotationData,
-} from "@/utils/type/api/GetNewsType"
+import { GetNewsData, MapInstance, MapkitInstance } from "@/utils/type/api/GetNewsType"
 import { RefObject } from "react"
 import { categoryStyleMap } from "./categoryStyleMap"
+import { MarkerAnnotationData } from "@/utils/type/api/common/GetAnnotationsType"
 
 /**
  * マーカー（アノテーション）の表示をする関数

--- a/src/utils/type/api/GetMissionType.ts
+++ b/src/utils/type/api/GetMissionType.ts
@@ -1,5 +1,5 @@
-import { MapAnnotationType } from "../map/MapAnnotationType"
+import { GetAnnotationsType } from "./common/GetAnnotationsType"
 
 export const FIRE_API_ENDPOINT = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/fire-trucks/missions`
 
-export type GetFireData = MapAnnotationType
+export type GetFireData = GetAnnotationsType

--- a/src/utils/type/api/GetNewsType.ts
+++ b/src/utils/type/api/GetNewsType.ts
@@ -1,3 +1,5 @@
+import { GetAnnotationsType } from "./common/GetAnnotationsType"
+
 export type MapInstance = mapkit.Map
 export type MapkitInstance = typeof mapkit
 
@@ -10,32 +12,4 @@ export const NEWS_API_ENDPOINT = `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/ne
  *  - GetNewsDataは、APIから取得するニュース・消防データの型で、mapkit.Annotationのデータ型に合わせた型。
  *  - APIから受け取ったGetNewsDataをアノテーションに使用したら、mapkit.Annotationのデータ型になると考えるといいかも。
  */
-export type GetNewsData = {
-  id: number
-  category: string // ニュースのカテゴリ
-  location: { lat: number; lng: number }
-  title: string // ニュースのタイトル
-  summary: string // ニュースの要約
-  contentBody: string // ニュースの本文
-  sourceName: string | null // ニュースの発信元
-  sourceUrl: string | null // 発信元のURL
-  clusteringIdentifier: string
-  data: MarkerAnnotationData
-  markerImgUrl?: string // マーカーの画像
-  publishedAt: Date // ニュースの公開日
-  createdAt: Date // DBに登録された日時
-}
-
-/**
- * Annotationデータのdataプロパティの型
- */
-export type MarkerAnnotationData = {
-  id: number
-  category: string
-  location: { lat: number; lng: number }
-  address: string | null
-  predictedLocation: string | null
-  link: string
-  publishedAt: Date
-  markerImgUrl: string
-}
+export type GetNewsData = GetAnnotationsType

--- a/src/utils/type/api/common/GetAnnotationsType.ts
+++ b/src/utils/type/api/common/GetAnnotationsType.ts
@@ -1,0 +1,32 @@
+/**
+ * GetNewsData・GetFireDataの型
+ */
+export type GetAnnotationsType = {
+  id: number
+  category: string // ニュースのカテゴリ
+  location: { lat: number; lng: number }
+  title: string // ニュースのタイトル
+  summary: string // ニュースの要約
+  contentBody: string // ニュースの本文
+  sourceName: string | null // ニュースの発信元
+  sourceUrl: string | null // 発信元のURL
+  clusteringIdentifier: string
+  data: MarkerAnnotationData
+  markerImgUrl?: string // マーカーの画像
+  publishedAt: Date // ニュースの公開日
+  createdAt: Date // DBに登録された日時
+}
+
+/**
+ * Annotationデータのdataプロパティの型
+ */
+export type MarkerAnnotationData = {
+  id: number
+  category: string
+  location: { lat: number; lng: number }
+  address: string | null
+  predictedLocation: string | null
+  link: string
+  publishedAt: Date
+  markerImgUrl: string
+}


### PR DESCRIPTION
- `layout.tsx`で`Head`コンポーネントを削除し、`Script`コンポーネントのIDを追加しました。
- `page.tsx`から未使用の`MapContainer`インポートを削除しました。
- `AppleMap.tsx`で不要な`mapOptions`を削除し、`annotationRefs`の型定義を明示化しました。
- `TweetList.tsx`で`img`タグを`Image`コンポーネントに置き換え、`convertDateLabelToDate.ts`で変数のスコープを修正しました。
- `renderAnnotation.ts`でアノテーションのループ処理を簡素化しました。